### PR TITLE
The path for gem binaries is missing a separator

### DIFF
--- a/resources/railsinstaller/setup_environment.bat
+++ b/resources/railsinstaller/setup_environment.bat
@@ -22,7 +22,7 @@ REM
 REM Add RUBY_DIR\bin to the PATH, DevKit\bin and then Git\cmd
 REM RUBY_DIR\bin takes higher priority to avoid other tools conflict
 REM
-SET PATH=%RUBY_DIR%\bin;%RUBY_DIR%lib\ruby\gems\1.8\bin;%ROOT_DIR%\DevKit\bin;%ROOT_DIR%\Git\cmd;%PATH%
+SET PATH=%RUBY_DIR%\bin;%RUBY_DIR%\lib\ruby\gems\1.8\bin;%ROOT_DIR%\DevKit\bin;%ROOT_DIR%\Git\cmd;%PATH%
 SET RUBY_DIR=
 SET ROOT_DIR=
 


### PR DESCRIPTION
C:\Sites>echo %PATH%
C:\RailsInstaller\Ruby1.8.7lib\ruby\gems\1.8\bin

is being corrected to Ruby1.8.7\lib
