### PR TITLE
Translate for brazilian portuguese

### DIFF
--- a/resources/railsinstaller/Default.isl
+++ b/resources/railsinstaller/Default.isl
@@ -12,3 +12,24 @@ SelectDirDesc=This is the location that Ruby, DevKit, Git, Rails and Sqlite will
 SelectDirLabel3=[name] will be installed into the following folder. Click Install to continue or click Browse to use a different one.
 SelectDirBrowseLabel=Please avoid any folder name that contains spaces (e.g. Program Files).
 DiskSpaceMBLabel=Required free disk space: ~[mb] MB
+
+[CustomMessages]
+IrbIconName=Interactive Ruby
+RubyGemsDocIconName=RubyGems Documentation Server
+CmdWithRailsIconName=Command Prompt with Ruby and Rails
+GitBashIconName=Git Bash
+ConfigureGitCheckBoxDescription=Configure git and ssh when installation has completed.
+SelectedTasksLog=Selected Tasks - Path: %d
+OlderWindowsVersionMsg=Looks like you've got on older, unsupported Windows version. Proceeding with a reduced feature set installation.
+InstallGitCheckBox=Install Git (recommended)
+AddToPathCheckBox=Add executables for Ruby, DevKit and Git (if checked above) to the PATH
+WebSiteLabel=Web Site:
+MailingListLabel=Mailing List:
+IRCLabel=IRC:
+InstallButton=&Install
+PrependingPathExtLog=Empty HKCU %s, prepending %PATHEXT% to new value
+PathUpdateLog=%s updated to: %s
+OriginalPathValueLog=Original %s: %s
+DeletedEmptyValueLog=Uninstaller deleted empty %s to match original config
+NoChangesNeedLog=No changes need for %s
+ItemAlreadyInPathLog=%s already on %s in original config; not modifying %s

--- a/resources/railsinstaller/Default.isl
+++ b/resources/railsinstaller/Default.isl
@@ -1,0 +1,14 @@
+[Messages]
+InstallingLabel=Installing [name], this will take a few minutes...
+WelcomeLabel1=Welcome to [name]!
+WelcomeLabel2=This will install [name/ver] on your computer which includes Ruby 1.9.3, Rails 3.2.14, Git, Sqlite3, DevKit, and TinyTDS with FreeTDS.  Please close any console applications before continuing.
+WizardLicense={#InstallerName} License Agreement
+LicenseLabel=
+LicenseLabel3=Please read the following License Agreements and accept the terms before continuing the installation.
+LicenseAccepted=I &accept all of the Licenses
+LicenseNotAccepted=I &decline any of the Licenses
+WizardSelectDir=Installation Destination and Optional Tasks
+SelectDirDesc=This is the location that Ruby, DevKit, Git, Rails and Sqlite will be installed to.
+SelectDirLabel3=[name] will be installed into the following folder. Click Install to continue or click Browse to use a different one.
+SelectDirBrowseLabel=Please avoid any folder name that contains spaces (e.g. Program Files).
+DiskSpaceMBLabel=Required free disk space: ~[mb] MB

--- a/resources/railsinstaller/LICENSE-BR.txt
+++ b/resources/railsinstaller/LICENSE-BR.txt
@@ -1,0 +1,29 @@
+Copyright (c) 2010-2012 RailsInstaller Team.
+
+Exceto:
+
+  * O Ruby tem seus direitos de cópia livre por Yukihiro Matsumoto.
+    http://www.ruby-lang.org/en/LICENSE.txt
+
+  * O DevKit é licenceado pelo projeto RubyInstaller:
+    http://rubyinstaller.org/
+
+  * O Git tem a licença GNU GPL v2.0
+    http://www.gnu.org/licenses/gpl-2.0.txt
+
+  * O Microsoft Visual C++ 2008 SP1 Redistributable Package (x86)
+    http://www.microsoft.com/downloads/en/details.aspx?familyid=a5c84275-3b97-4ab7-a40d-3802b2af5fc2&displaylang=en
+
+  * O FreeTDS tem a licença GNU LGPL.
+    http://www.gnu.org/licenses/lgpl-2.0.html
+  
+  * Bibliotecas de terceiros (OpenSSL, ZLib, etc.)
+
+
+Este software é distrubuído sobre os termos da licença MIT.
+
+"Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."

--- a/resources/railsinstaller/Languages/BrazilianPortuguese.isl
+++ b/resources/railsinstaller/Languages/BrazilianPortuguese.isl
@@ -1,14 +1,35 @@
 [Messages]
 InstallingLabel=Instalando [name], isto pode levar alguns minutos...
 WelcomeLabel1=Bem vindo ao [name]!
-WelcomeLabel2=Isto irá instalar o [name/ver] no seu computado, o qual inclui Ruby 1.9.3, Rails 3.2.14, Git, Sqlite3, DevKit, and TinyTDS with FreeTDS. Por favor feche qualquer aplicação console antes de continuar.
+WelcomeLabel2=Isto irá instalar o [name/ver] no seu computado, o qual inclui Ruby 1.9.3, Rails 3.2.14, Git, Sqlite3, DevKit, e TinyTDS com FreeTDS. Por favor feche qualquer aplicação console antes de continuar.
 WizardLicense=Licença do {#InstallerName}
 LicenseLabel=
 LicenseLabel3=Por favor leia os seguintes Termos de Licença e aceite-os antes de continuar a instalação.
-LicenseAccepted=Eu &aceito todas as licenças 
+LicenseAccepted=Eu &aceito todas as licenças
 LicenseNotAccepted=Eu &não aceito alguma das licenças
 WizardSelectDir=Destino da instalação e Tarefas opcionais
 SelectDirDesc=Está é a localização onde o Ruby, DevKit, Git, Rails and Sqlite será instalado.
-SelectDirLabel3=[name] será instalado dentro da seguinte pasta. Clique em Instalar para continuar ou clique em Procurar para usar um diferente.
-SelectDirBrowseLabel=Por favor evite qualquer nome de pasta que contena espaçõs (ex. "Arquivos de Programas").
+SelectDirLabel3=O [name] será instalado dentro da seguinte pasta. Clique em Instalar para continuar ou clique em Procurar para usar uma diferente.
+SelectDirBrowseLabel=Evite qualquer nome de pasta que contenha espaços (ex. Arquivos de Programas).
 DiskSpaceMBLabel=Espaço em disco necessário: ~[mb] MB
+
+[CustomMessages]
+IrbIconName=Ruby Interativo
+RubyGemsDocIconName=Servidor de Documentação do RubyGems
+CmdWithRailsIconName=Linha de Comando com Ruby e Rails
+GitBashIconName=Git Bash
+ConfigureGitCheckBoxDescription=Configurar git e ssh quando a instalação terminar.
+SelectedTasksLog=Tarefas selecionadas - Path: %d
+OlderWindowsVersionMsg=Parece que você tem uma versão antiga e não suportada do Windows. Procedendo com uma instalação com recursos reduzidos.
+InstallGitCheckBox=Instalar Git (recomendado)
+AddToPathCheckBox=Adicionar executáveis Ruby, DevKit e Git (se estiver checado acima) ao PATH
+WebSiteLabel=Site:
+MailingListLabel=Lista de Email:
+IRCLabel=IRC:
+InstallButton=&Instalar
+PrependingPathExtLog=HKCU vazio %s, adicionando %PATHEXT% ao novo valor
+PathUpdateLog=%s atualizado para: %s
+OriginalPathValueLog=%s original: %s
+DeletedEmptyValueLog=O desinstalador deletou o valor vazio %s para corresponder a configuração original
+NoChangesNeedLog=Sem alterações necessárias para %s
+ItemAlreadyInPathLog=%s já está em %s originalmente; %s não será modificado

--- a/resources/railsinstaller/Languages/BrazilianPortuguese.isl
+++ b/resources/railsinstaller/Languages/BrazilianPortuguese.isl
@@ -1,0 +1,14 @@
+[Messages]
+InstallingLabel=Instalando [name], isto pode levar alguns minutos...
+WelcomeLabel1=Bem vindo ao [name]!
+WelcomeLabel2=Isto irá instalar o [name/ver] no seu computado, o qual inclui Ruby 1.9.3, Rails 3.2.14, Git, Sqlite3, DevKit, and TinyTDS with FreeTDS. Por favor feche qualquer aplicação console antes de continuar.
+WizardLicense=Licença do {#InstallerName}
+LicenseLabel=
+LicenseLabel3=Por favor leia os seguintes Termos de Licença e aceite-os antes de continuar a instalação.
+LicenseAccepted=Eu &aceito todas as licenças 
+LicenseNotAccepted=Eu &não aceito alguma das licenças
+WizardSelectDir=Destino da instalação e Tarefas opcionais
+SelectDirDesc=Está é a localização onde o Ruby, DevKit, Git, Rails and Sqlite será instalado.
+SelectDirLabel3=[name] será instalado dentro da seguinte pasta. Clique em Instalar para continuar ou clique em Procurar para usar um diferente.
+SelectDirBrowseLabel=Por favor evite qualquer nome de pasta que contena espaçõs (ex. "Arquivos de Programas").
+DiskSpaceMBLabel=Espaço em disco necessário: ~[mb] MB

--- a/resources/railsinstaller/railsinstaller.iss
+++ b/resources/railsinstaller/railsinstaller.iss
@@ -106,16 +106,16 @@ Source: setup_environment.bat; DestDir: {app}\{#RubyPath}
 ;Root: HKCU; Subkey: Software\RailsInstaller; ValueType: string; ValueName: ; ValueData: ; Flags: uninsdeletevalue uninsdeletekeyifempty; Check: IsNotAdmin
 
 [Icons]
-Name: {group}\Interactive Ruby; Filename: {app}\{#RubyPath}\bin\irb.bat; WorkingDir: {app}\{#RubyPath} ; IconFilename: {app}\{#RubyPath}\bin\ruby.exe; Flags: createonlyiffileexists
-Name: {group}\RubyGems Documentation Server; Filename: {app}\{#RubyPath}\bin\gem.bat; Parameters: server; IconFilename: {app}\{#RubyPath}\bin\ruby.exe; Flags: createonlyiffileexists runminimized
-Name: {group}\Command Prompt with Ruby and Rails; Filename: {sys}\cmd.exe; Parameters: /E:ON /K {app}\{#RubyPath}\setup_environment.bat {app}; WorkingDir: {sd}\Sites; IconFilename: {sys}\cmd.exe; Flags: createonlyiffileexists
-Name: {group}\Git Bash; Filename: {sys}\cmd.exe; Parameters: "/c """"{app}\Git\bin\sh.exe"" --login -i"""; WorkingDir: {sd}\Sites; IconFilename: {app}\Git\etc\git.ico; Check: InstallGit; Flags: createonlyiffileexists
+Name: {group}\{cm:IrbIconName}; Filename: {app}\{#RubyPath}\bin\irb.bat; WorkingDir: {app}\{#RubyPath}; IconFilename: {app}\{#RubyPath}\bin\ruby.exe; Flags: createonlyiffileexists
+Name: {group}\{cm:RubyGemsDocIconName}; Filename: {app}\{#RubyPath}\bin\gem.bat; Parameters: server; IconFilename: {app}\{#RubyPath}\bin\ruby.exe; Flags: createonlyiffileexists runminimized
+Name: {group}\{cm:CmdWithRailsIconName}; Filename: {sys}\cmd.exe; Parameters: /E:ON /K {app}\{#RubyPath}\setup_environment.bat {app}; WorkingDir: {sd}\Sites; IconFilename: {sys}\cmd.exe; Flags: createonlyiffileexists
+Name: {group}\{cm:GitBashIconName}; Filename: {sys}\cmd.exe; Parameters: "/c """"{app}\Git\bin\sh.exe"" --login -i"""; WorkingDir: {sd}\Sites; IconFilename: {app}\Git\etc\git.ico; Check: InstallGit; Flags: createonlyiffileexists
 ; {%HOMEPATH%}
 Name: {group}\{cm:UninstallProgram,{#InstallerName}}; Filename: {uninstallexe}
 
 [Run]
 Filename: "{app}\{#RubyPath}\bin\ruby.exe"; Parameters: "dk.rb install --force"; WorkingDir: "{app}\DevKit"; Flags: runhidden
-Filename: {sys}\cmd.exe; Parameters: /E:ON /K {app}\{#RubyPath}\setup_environment.bat {app}; WorkingDir: {sd}\Sites; Description: "Configure git and ssh when installation has completed."; Check: InstallGit; Flags: postinstall nowait skipifsilent
+Filename: {sys}\cmd.exe; Parameters: /E:ON /K {app}\{#RubyPath}\setup_environment.bat {app}; WorkingDir: {sd}\Sites; Description: "{cm:ConfigureGitCheckBoxDescription}"; Check: InstallGit; Flags: postinstall nowait skipifsilent
 
 ; TODO: Instead of running the full vcredist, simply extract and bundle the dll
 ;       files with an associated manifest.
@@ -138,17 +138,15 @@ begin
   begin
     if UsingWinNT then
     begin
-      Log(Format('Selected Tasks - Path: %d', [PathChkBox.State]));
+      Log(Format(CustomMessage('SelectedTasksLog'), [PathChkBox.State]));
 
       if IsModifyPath then
         ModifyPath([ExpandConstant('{app}') + '\{#RubyPath}\bin']);
-		if InstallGit then
-			ModifyPath([ExpandConstant('{app}') + '\Git\cmd']);
+  		if InstallGit then
+  			ModifyPath([ExpandConstant('{app}') + '\Git\cmd']);
 
     end else
-      MsgBox('Looks like you''ve got on older, unsupported Windows version.' #13 +
-             'Proceeding with a reduced feature set installation.',
-             mbInformation, MB_OK);
+      MsgBox(CustomMessage('OlderWindowsVersionMsg'), mbInformation, MB_OK);
   end;
 end;
 

--- a/resources/railsinstaller/railsinstaller.iss
+++ b/resources/railsinstaller/railsinstaller.iss
@@ -84,6 +84,7 @@ SignTool=risigntool sign /a /d $q{#InstallerNameWithVersion}$q /du $q{#Installer
 
 [Languages]
 Name: en; MessagesFile: compiler:Default.isl
+Name: pt-br; MessagesFile: compiler:Languages\BrazilianPortuguese.isl
 
 [Messages]
 en.InstallingLabel=Installing [name], this will take a few minutes...

--- a/resources/railsinstaller/railsinstaller.iss
+++ b/resources/railsinstaller/railsinstaller.iss
@@ -60,7 +60,6 @@ AppVersion={#InstallerVersion}
 DefaultGroupName={#InstallerName}
 DefaultDirName={sd}\RailsInstaller
 DisableProgramGroupPage=true
-LicenseFile=LICENSE.txt
 Compression=lzma2/ultra64
 SolidCompression=true
 AlwaysShowComponentsList=false
@@ -83,8 +82,8 @@ SignTool=risigntool sign /a /d $q{#InstallerNameWithVersion}$q /du $q{#Installer
 #endif
 
 [Languages]
-Name: en; MessagesFile: compiler:Default.isl
-Name: pt-br; MessagesFile: compiler:Languages\BrazilianPortuguese.isl
+Name: "en"; MessagesFile: "compiler:Default.isl"; LicenseFile: "LICENSE.txt"
+Name: "pt-br"; MessagesFile: "compiler:Languages\BrazilianPortuguese.isl"; LicenseFile: "LICENSE-BR.txt"
 
 [Messages]
 en.InstallingLabel=Installing [name], this will take a few minutes...

--- a/resources/railsinstaller/railsinstaller.iss
+++ b/resources/railsinstaller/railsinstaller.iss
@@ -82,23 +82,8 @@ SignTool=risigntool sign /a /d $q{#InstallerNameWithVersion}$q /du $q{#Installer
 #endif
 
 [Languages]
-Name: "en"; MessagesFile: "compiler:Default.isl"; LicenseFile: "LICENSE.txt"
-Name: "pt-br"; MessagesFile: "compiler:Languages\BrazilianPortuguese.isl"; LicenseFile: "LICENSE-BR.txt"
-
-[Messages]
-en.InstallingLabel=Installing [name], this will take a few minutes...
-en.WelcomeLabel1=Welcome to [name]!
-en.WelcomeLabel2=This will install [name/ver] on your computer which includes Ruby 2.0.0, Rails 4.1.5, Git, Sqlite3, DevKit, and TinyTDS with FreeTDS.  Please close any console applications before continuing.
-en.WizardLicense={#InstallerName} License Agreement
-en.LicenseLabel=
-en.LicenseLabel3=Please read the following License Agreements and accept the terms before continuing the installation.
-en.LicenseAccepted=I &accept all of the Licenses
-en.LicenseNotAccepted=I &decline any of the Licenses
-en.WizardSelectDir=Installation Destination and Optional Tasks
-en.SelectDirDesc=This is the location that Ruby, DevKit, Git, Rails and Sqlite will be installed to.
-en.SelectDirLabel3=[name] will be installed into the following folder. Click Install to continue or click Browse to use a different one.
-en.SelectDirBrowseLabel=Please avoid any folder name that contains spaces (e.g. Program Files).
-en.DiskSpaceMBLabel=Required free disk space: ~[mb] MB
+Name: "en"; MessagesFile: "compiler:Default.isl,Default.isl"; LicenseFile: "LICENSE.txt"
+Name: "brazilianportuguese"; MessagesFile: "compiler:Languages\BrazilianPortuguese.isl,Languages\BrazilianPortuguese.isl"; LicenseFile: "LICENSE-BR.txt"
 
 [Files]
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files

--- a/resources/railsinstaller/railsinstaller_gui.iss
+++ b/resources/railsinstaller/railsinstaller_gui.iss
@@ -71,17 +71,17 @@ begin
   GitChkBox := TCheckBox.Create(Page);
   GitChkBox.Parent := Page.Surface;
   GitChkBox.State := cbChecked;
-  GitChkBox.Caption := 'Install Git (recommended) ';
+  GitChkBox.Caption := CustomMessage('InstallGitCheckBox');
   GitChkBox.Alignment := taRightJustify;
   GitChkBox.Top := ScaleY(95);
   GitChkBox.Left := ScaleX(18);
   GitChkBox.Width := Page.SurfaceWidth;
   GitChkBox.Height := ScaleY(17);
-  
+
   PathChkBox := TCheckBox.Create(Page);
   PathChkBox.Parent := Page.Surface;
   PathChkBox.State := cbChecked;
-  PathChkBox.Caption := 'Add executables for Ruby, DevKit and Git (if checked above) to the PATH ';
+  PathChkBox.Caption := CustomMessage('AddToPathCheckBox');
   PathChkBox.Alignment := taRightJustify;
   PathChkBox.Top := ScaleY(125);
   PathChkBox.Left := ScaleX(18);
@@ -97,7 +97,7 @@ begin
   TmpLabel.Top := ScaleY(180);
   TmpLabel.Left := ScaleX(176);
   TmpLabel.AutoSize := True;
-  TmpLabel.Caption := 'Web Site:';
+  TmpLabel.Caption := CustomMessage('WebSiteLabel');
 
   URLText := TNewStaticText.Create(HostPage);
   URLText.Parent := HostPage;
@@ -114,7 +114,7 @@ begin
   TmpLabel.Top := ScaleY(196);
   TmpLabel.Left := ScaleX(176);
   TmpLabel.AutoSize := True;
-  TmpLabel.Caption := 'Mailing List:';
+  TmpLabel.Caption := CustomMessage('MailingListLabel');
 
   URLText := TNewStaticText.Create(HostPage);
   URLText.Parent := HostPage;
@@ -131,7 +131,7 @@ begin
   TmpLabel.Top := ScaleY(212);
   TmpLabel.Left := ScaleX(176);
   TmpLabel.AutoSize := True;
-  TmpLabel.Caption := 'IRC:';
+  TmpLabel.Caption := CustomMessage('IRCLabel');
 
   URLText := TNewStaticText.Create(HostPage);
   URLText.Parent := HostPage;
@@ -158,6 +158,6 @@ end;
 procedure CurPageChanged(CurPageID: Integer);
 begin
   if CurPageID = wpSelectDir then
-    WizardForm.NextButton.Caption := '&Install';
+    WizardForm.NextButton.Caption := CustomMessage('InstallButton');
 end;
 

--- a/resources/railsinstaller/util.iss
+++ b/resources/railsinstaller/util.iss
@@ -59,12 +59,12 @@ begin
 
   try
     RegQueryStringValue(RootKey, SubKey, RegValue, OrigData);
-    Log('Original ' + AnsiUppercase(RegValue) + ': ' + OrigData);
+    Log(Format(CustomMessage('OriginalPathValueLog'), [AnsiUppercase(RegValue), OrigData]));
 
     // ensure originally empty users PATHEXT also contains system values
     if (RootKey = HKCU) and (AnsiUppercase(RegValue) = 'PATHEXT') and (OrigData = '') then
     begin
-      Log('Empty HKCU ' + AnsiUppercase(RegValue) + ', prepending %PATHEXT% to new value');
+      Log(Format(CustomMessage('PrependingPathExtLog'), [AnsiUppercase(RegValue)]));
       OrigData := ('%' + RegValue + '%');
     end;
 
@@ -80,7 +80,7 @@ begin
         'PATH': RegWriteExpandStringValue(RootKey, SubKey, 'Path', NewPathish);
         'PATHEXT': RegWriteExpandStringValue(RootKey, SubKey, 'PATHEXT', NewPathish);
       end;
-      Log(AnsiUppercase(RegValue) + ' updated to: ' + NewPathish);
+      Log(Format(CustomMessage('PathUpdateLog'), [AnsiUppercase(RegValue), NewPathish])  );
 
       // remove values if empty after uninstaller reverts its mods
       if IsUninstaller then
@@ -92,13 +92,12 @@ begin
           if (Tmp = '') or (Tmp = TmpExpandable) then
           begin
             RegDeleteValue(RootKey, SubKey, RegValue);
-            Log('uninstaller deleted empty ' + AnsiUppercase(RegValue) +
-                ' to match original config');
+            Log(Format(CustomMessage('DeletedEmptyValueLog'), [AnsiUppercase(RegValue)]));
           end;
         end;
       end;
     end else  // no reg change needed
-      Log('no changes need for ' + AnsiUppercase(RegValue));
+      Log(Format(CustomMessage('NoChangesNeedLog'), [AnsiUppercase(RegValue)]));
   finally
     PathishList.Free;
   end;
@@ -192,8 +191,7 @@ begin
         end;
         RegChangeFlag := True;
       end else  // already in existing config, no need for update; log it
-        Log(Item + ' already on ' + AnsiUppercase(RegValue) +
-          ' in original config; not modifying ' + AnsiUppercase(RegValue));
+        Log(Format(CustomMessage('ItemAlreadyInPathLog'), [Item, AnsiUppercase(RegValue), AnsiUppercase(RegValue)]));
     end else  // uninstalling...
     begin
       I := SrcList.IndexOf(Item);


### PR DESCRIPTION
So, I was working on this since yesterday. :smiley:

It was really easy, since Inno already supports i18n. But I simplified a little how to translate, separating the messages into other files. So basically, if anyone want to translate, just need to:
- Copy the `resources/railsinstaller/Default.isl` to the `Languages` subdirectory and rename it to the correct language name (e.g. `Russian.isl`).
- Translate the messages inside it.
- Add the translation to the `[Languages]` section in `railsinstaller.iss` file.

> e.g.
> `Name: "russian"; MessagesFile: "compiler:Languages\Russian.isl,Languages\Russian.isl"; LicenseFile: "LICENSE-RU.txt"`
- Be happy. :smile: 

So, about how the translations are loaded. In [this help file](http://www.jrsoftware.org/ishelp/index.php?topic=languagessection), says that Inno Setup search for a `LanguageID` that match the UI language of the user machine. These `LanguageID`s are already setted by the default language scripts of Inno, that are in `%InnoInstallationDir%/Languages`, so, if you use one of them, you'll be covered on tranlation loading.

The only one behavior changed is that now: before open the main installation wizard, a window asking the user the language for the installation is shown. Yes, even if the language is discovered by Inno it will show the window, but with the language already assigned to the UI language. But, I think that this will not annoy at all, so you think?
