### PR TITLE
Add Vista as the minimum supported Windows version fixes #26

### DIFF
--- a/resources/railsinstaller/railsinstaller.iss
+++ b/resources/railsinstaller/railsinstaller.iss
@@ -77,6 +77,7 @@ WizardSmallImageFile={#ResourcesPath}\images\RailsInstallerWizardImageSmall.bmp
 PrivilegesRequired=lowest
 ChangesAssociations=yes
 ChangesEnvironment=yes
+MinVersion=6.0
 
 #if Defined(SignPackage) == 1
 SignTool=risigntool sign /a /d $q{#InstallerNameWithVersion}$q /du $q{#InstallerHomepage}$q /t $qhttp://timestamp.comodoca.com/authenticode$q $f


### PR DESCRIPTION
This makes Vista the oldest version that the installer will run on. EXE installs just fine on my Vista VM
