### PR TITLE
Fix path of gem binstubs

### DIFF
--- a/resources/railsinstaller/railsinstaller.iss
+++ b/resources/railsinstaller/railsinstaller.iss
@@ -130,6 +130,7 @@ Name: {group}\{cm:UninstallProgram,{#InstallerName}}; Filename: {uninstallexe}
 
 [Run]
 Filename: "{app}\{#RubyPath}\bin\ruby.exe"; Parameters: "dk.rb install --force"; WorkingDir: "{app}\DevKit"; Flags: runhidden
+Filename: "{app}\{#RubyPath}\bin\gem.bat"; Parameters: "pristine --all --only-executables"; WorkingDir: "{app}\{#RubyPath}\bin"; Flags: runhidden
 Filename: {sys}\cmd.exe; Parameters: /E:ON /K {app}\{#RubyPath}\setup_environment.bat {app}; WorkingDir: {sd}\Sites; Description: "Configure git and ssh when installation has completed."; Check: InstallGit; Flags: postinstall nowait skipifsilent
 
 ; TODO: Instead of running the full vcredist, simply extract and bundle the dll


### PR DESCRIPTION
## Overview

Since rubygems v2.4.2, Windows binstubs for gem executables are generated with a hardcoded path to Ruby. This leads to the binstubs shipping with RailsInstaller-Windows being unusable, because they reference the Ruby path on the maintainer machine, rather than the machine that executed the installer (see #81).

This is due to a change in rubygems, which explicitely hardcodes the Ruby path in the binstubs. The intend was to work around a Bundler issue (see https://github.com/rubygems/rubygems/pull/942, which is very well documented).

## The fix

The author of the patch notes that it makes Ruby installations non-portable across machines - which is exactly the issue that we encounter there. The intended workaround for people needing
portable installations is to re-generate the binstubs locally, by executing `gem pristine --all --executables-only`.

This is how this PR implements the fix: it simply re-generates the binstubs with the correct path at the end of the installation.

This fixes a clean installation of RailsInstaller-Windows not being able to execute neither `rails`, `bundler` or many other binstubs. /cc @XhmikosR @emachnic 

## How to test

If you wish to test the fix:

1. Build the installer locally,
2. Run the installer,
3. Check that the content of `C:\RailsInstaller\Ruby2.2.0\bin\bunder.bat` references a correct path to `ruby.exe` (instead of a path relative to the directory in which the installer was built).

## Future work

In the future, I may attempt to fix the issue upstream in rubygems, by allowing `--env-shebang` to generate a portable Ruby path again, as it was suggested in the original pull request.