### PR TITLE
Fix RubyGems HTTPS downloads

### DIFF
--- a/config/railsinstaller.yml
+++ b/config/railsinstaller.yml
@@ -46,7 +46,7 @@
   :title: Ruby 2.2.0
   :name: Ruby220
   :regex: '^.*$'
-  :url: "http://s3.amazonaws.com/railsinstaller/Resources/ruby-2.2.4-i386-mingw32.7z"
+  :url: "http://dl.bintray.com/oneclick/rubyinstaller/ruby-2.2.6-i386-mingw32.7z"
   :rename: Ruby2.2.0
 
 :git:

--- a/lib/railsinstaller/actions.rb
+++ b/lib/railsinstaller/actions.rb
@@ -9,7 +9,7 @@ module RailsInstaller
 
     components.each do |package|
       section  package.title
-      download package
+      download package.url
       extract  package
     end
 

--- a/lib/railsinstaller/downloads.rb
+++ b/lib/railsinstaller/downloads.rb
@@ -5,8 +5,8 @@ module RailsInstaller
 
   # Original download() code taken from Rubinius and then butchered ;)
   # https://github.com/evanphx/rubinius/blob/master/configure#L307-350
-  def self.download(package, count = 3)
-   filename = File.basename(package.url)
+  def self.download(url, filename = nil, count = 3)
+   filename ||= File.basename(url)
 
    return if File.exists?(File.join(RailsInstaller::Archives, filename))
 
@@ -20,9 +20,9 @@ module RailsInstaller
         http = Net::HTTP
       end
 
-      uri = URI.parse(package.url)
+      uri = URI.parse(url)
 
-      print "Downloading from #{package.url} to #{RailsInstaller::Archives}\n" if $Flags[:verbose]
+      print "Downloading from #{url} to #{RailsInstaller::Archives}/#{filename}\n" if $Flags[:verbose]
       http.get_response(uri) do |response|
 
         case response
@@ -38,8 +38,8 @@ module RailsInstaller
           when Net::HTTPRedirection
             raise "Too many redirections for the original url, halting." if count <= 0
             print "Redirected to #{response["Location"]}\n" if $Flags[:verbose]
-            package.url = response["location"]
-            return download(package, count - 1)
+            url = response["location"]
+            return download(url, filename, count - 1)
 
           when Net::HTTPOK
             temp_file = Tempfile.new("download-#{filename}")

--- a/lib/railsinstaller/methods.rb
+++ b/lib/railsinstaller/methods.rb
@@ -305,7 +305,7 @@ module RailsInstaller
 
   # MSVC Runtime 2008 is Required for Postgresql Server
   def self.stage_msvc_runtime
-    download(MsvcRuntime)
+    download(MsvcRuntime.url)
     pkg_path = File.join(RailsInstaller::Stage, "pkg")
 
     FileUtils.mkdir_p(pkg_path) unless File.exist?(pkg_path)


### PR DESCRIPTION
Currently a fresh installation of RailsInstaller-Windows produces a `gem` command that cannot download gems from any HTTPS source (#58). This is mostly visible when running the `rake new` command : it will try to `bundle install`, and rapidly fail with an SSL error.

This is because the `rubygems` version packaged with Ruby 2.2.4 doesn't embed all the required root certificates for establishing a connection to https://rubygems.org. However `rubygems` has been fixed in Ruby 2.2.6 - so this is just a matter of upgrading the Ruby version.

For this, this MR has two commits:

- **Change the RubyInstaller URL for `2.2.4` to `2.2.6`**. Easy, works like a charm, and fixes the SSL issue.
- **When packaging the installer, retain archive filenames on HTTP redirects.** Currently if an HTTP redirect occurs when downloading RubyInstaller, the filename of the archive will change. And lo, this is what happen with the new 2.2.6 URL. This commit ensures that the original archive filename will be kept at build-time.

This should result in a fresh RailsInstaller setup being able to run `rails new` without issue. /cc @emachnic