### PR TITLE
Fix rake build procedure on downloading HTTPS tarball.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ built and packaged via rake tasks.
 
   * Methods called by the actions.rb file are implemented by lib/railsinstaller/methods.rb.
 
+1. Set `SSL_CERT_FILE` environment variable.
+
+    ```bash
+    SET SSL_CERT_FILE=C:\path\to\cacert.pem
+    ruby -e 'p ENV["SSL_CERT_FILE"]'
+    C:\path\to\cacert.pem  # This result is OK
+
+    ruby -e 'p ENV["SSL_CERT_FILE"]'
+    nil                    # This result is NG
+    ```
+
 1. Next build all components onto the stage (into the stage/ directory)
 
     ```bash


### PR DESCRIPTION
rake build fails on downloading HTTPS tarball. I met below error. 

```
C:/Ruby21-x64/lib/ruby/2.1.0/net/http.rb:923:in `connect': SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed (OpenSSL::SSL::SSLError)
        from C:/Ruby21-x64/lib/ruby/2.1.0/net/http.rb:923:in `block in connect'
        from C:/Ruby21-x64/lib/ruby/2.1.0/timeout.rb:75:in `timeout'
        from C:/Ruby21-x64/lib/ruby/2.1.0/net/http.rb:923:in `connect'
        from C:/Ruby21-x64/lib/ruby/2.1.0/net/http.rb:863:in `do_start'
        from C:/Ruby21-x64/lib/ruby/2.1.0/net/http.rb:852:in `start'
        from C:/Ruby21-x64/lib/ruby/2.1.0/net/http.rb:583:in `start'
        from C:/Ruby21-x64/lib/ruby/2.1.0/net/http.rb:478:in `get_response'
        from -e:1:in `<main>'
```

bsdtar in config/railsinstaller.yml, url is "http://downloads.sourceforge.net/mingw/basic-bsdtar-2.8.3-1-mingw32-bin.zip. But bsdtar was redirected to https://downloads.sourceforge.net/project/mingw/MinGW/Extension/bsdtar/basic-bsdtar-2.8.3-1/basic-bsdtar-2.8.3-1-mingw32-bin.zip.

This URL causes OpenSSL::SSL::SSLError like below.

```
$ ruby -r net/http -r uri -e 'Net::HTTP.get_response(URI.parse("https://downloads.sourceforge.net/project/mingw/MinGW/Extension/bsdtar/basic-bsdtar-2.8.3-1/basic-bsdtar-2.8.3-1-mingw32-bin.zip"))'
C:/Ruby21-x64/lib/ruby/2.1.0/net/http.rb:923:in `connect': SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed (OpenSSL::SSL::SSLError)
```

I set env var to fix that. I tested with using http://curl.haxx.se/ca/cacert.pem.